### PR TITLE
Issue 1: [fix] Checkout out of default remote branch fails

### DIFF
--- a/bin/list-git-configs.sh
+++ b/bin/list-git-configs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# List all git configs in order of precedence (highest to lowest)
+git config --list --show-origin | grep 'file:' | awk '{print $1}' | sed -e 's/^file://g' -e "s|$HOME|~|" | sort | uniq

--- a/git/git-recon.dev.gitconfig
+++ b/git/git-recon.dev.gitconfig
@@ -30,19 +30,20 @@
     fi; \
     localBranches=$(git for-each-ref --format='%(refname:short)' --sort=-committerdate refs/heads/ | tr '\n' '@'); \
     remoteBranch=$(git for-each-ref --count=${count} --sort=-committerdate refs/remotes/ --format='%(refname:short)' | sed -n ${count}p); \
-    : 'If remote branch is the 'HEAD' pointer, check out the default branch.'; \
-    if [[ $remoteBranch == */HEAD ]]; then \
+    : 'If remote branch is the 'HEAD' pointer or the bare origin, it is the default branch.'; \
+    if [[ $remoteBranch == */HEAD || $remoteBranch != *"/"* ]]; then \
       : 'Get the name of the remote from remoteBranch'; \
       remote=$(echo $remoteBranch | awk -F/ '{print $1}'); \
       default_branch=$(git print-default-branch $remote); \
       echo \"Checking out default branch '$default_branch'\"; \
       remoteBranch=$remote/$default_branch; \
     fi; \
+    exit 0; \
     : 'If branch exists locally check it out. Otherwise, create a local branch that tracks the remote branch.'; \
     branchWithOption=$(echo $remoteBranch | awk -v localBranches="@"$localBranches -v remoteBranch=$remoteBranch \
       '{ \
         branch = substr($NF, index($NF, \"/\") + 1); \
-       if (match(localBranches, \"@\"branch\"@\") != 0) \
+        if (match(localBranches, \"@\"branch\"@\") != 0) \
           print branch; \
         else \
           print \"--track \" remoteBranch; \

--- a/git/git-recon.gitconfig
+++ b/git/git-recon.gitconfig
@@ -30,19 +30,20 @@
     fi; \
     localBranches=$(git for-each-ref --format='%(refname:short)' --sort=-committerdate refs/heads/ | tr '\n' '@'); \
     remoteBranch=$(git for-each-ref --count=${count} --sort=-committerdate refs/remotes/ --format='%(refname:short)' | sed -n ${count}p); \
-    : 'If remote branch is the 'HEAD' pointer, check out the default branch.'; \
-    if [[ $remoteBranch == */HEAD ]]; then \
+    : 'If remote branch is the 'HEAD' pointer or the bare origin, it is the default branch.'; \
+    if [[ $remoteBranch == */HEAD || $remoteBranch != *"/"* ]]; then \
       : 'Get the name of the remote from remoteBranch'; \
       remote=$(echo $remoteBranch | awk -F/ '{print $1}'); \
       default_branch=$(git print-default-branch $remote); \
       echo \"Checking out default branch '$default_branch'\"; \
       remoteBranch=$remote/$default_branch; \
     fi; \
+    exit 0; \
     : 'If branch exists locally check it out. Otherwise, create a local branch that tracks the remote branch.'; \
     branchWithOption=$(echo $remoteBranch | awk -v localBranches="@"$localBranches -v remoteBranch=$remoteBranch \
       '{ \
         branch = substr($NF, index($NF, \"/\") + 1); \
-       if (match(localBranches, \"@\"branch\"@\") != 0) \
+        if (match(localBranches, \"@\"branch\"@\") != 0) \
           print branch; \
         else \
           print \"--track \" remoteBranch; \


### PR DESCRIPTION
# Fixes

- Fixed the issue that `git checkout-nth-remote` (or its shortcut equivalent) fails if Git lists the default remote branch as `<remote>` rather than `<remote>/HEAD`. Might be related to the Git version. Fixes #1.

# Utils

- Added the script `list-git-configs.sh` to assist debugging of Git configs. It lists all applicable Git configs in descending order of precedence.
